### PR TITLE
Added 480p to p2p desktop sharing

### DIFF
--- a/desktopCapture-p2p/background/captureDesktop.js
+++ b/desktopCapture-p2p/background/captureDesktop.js
@@ -131,6 +131,11 @@ function captureDesktop() {
             resolutions.maxHeight = 720;
         }
 
+        if (_resolutions === '480p') {
+            resolutions.maxWidth = 853;
+            resolutions.maxHeight = 480;
+        }
+
         if (_resolutions === '360p') {
             resolutions.maxWidth = 640;
             resolutions.maxHeight = 360;

--- a/desktopCapture-p2p/extension-pages/options.html
+++ b/desktopCapture-p2p/extension-pages/options.html
@@ -127,6 +127,7 @@ input {
         <option value="4K">4K (2160p)</option>
         <option value="1080p">Full-HD (1080p)</option>
         <option value="720p">HD (720p)</option>
+        <option value="480p">SD (480p)</option>
         <option value="360p">SD (360p)</option>
     </select>
     </div>


### PR DESCRIPTION
I'm streaming 480p content over the desktop webrtc sharing extension and wanted to save as much bandwidth as I could.